### PR TITLE
Stop deleting messages needlessly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ impl EventHandler for MainHandler {
         }
 
         if BLACKLISTED_PHRASES.contains(&message.content.as_str()) {
-            check!(message.delete(&ctx).await);
+            check!(message.react(&ctx, '🇱').await);
             return;
         }
 


### PR DESCRIPTION
### Changes

- [ ] New Feature(s)
- [x] Bug Fixes
- [ ] Documentation
- [ ] Other: \_____

## Description

There has been this terrible bug in the past few days where Danktronics Bot was deleting any message with the exact content "L" so I have rectified the issue.